### PR TITLE
refactor: replace slash commands with triple-underscore prefix for up…

### DIFF
--- a/aicli.plugin.zsh
+++ b/aicli.plugin.zsh
@@ -186,9 +186,9 @@ _aicli_newchat() {
 
     local query="$*"
 
-    # Check for slash commands (e.g., / update)
+    # Check for slash commands (e.g., ??? update)
     local -a args=("${(@)query}")
-    if [[ $#args -ge 2 && ${args[1]} == "/" && ${args[2]} == "update" ]]; then
+    if [[ $#args -ge 2 && ${args[1]} == "???" && ${args[2]} == "update" ]]; then
         _aicli_update
         return
     fi


### PR DESCRIPTION
…date

Changed slash command syntax (`/ update`) to triple-underscore prefix (`??? update`) for consistency and to avoid conflicts with shell or system commands that might start with `/`.